### PR TITLE
feat: use zod codecs for transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ This is a JavaScript library for Node.JS, browers and React Native to issue and 
 npm i @owf/mdoc
 ```
 
+## React Native Support
+
+When using this library in React Native you may need to add a polyfill for TextDecoder. 
+
+You can confirm this by checking if `global.TextDecoder` is available. It should be available for React Native > 0.85 or Expo SDK > 52.
+
+If it is not available, make sure to add a polyfill like [this one](https://github.com/EvanBacon/text-decoder).
 
 ## Contributing
 

--- a/src/utils/transformers.ts
+++ b/src/utils/transformers.ts
@@ -1,188 +1,42 @@
-const BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+import z from 'zod'
 
-const bytesToBase64 = (bytes: Uint8Array): string => {
-  let result = ''
-  let i: number
+const base64ToBytes = z.codec(z.base64(), z.instanceof(Uint8Array), {
+  decode: (base64String) => z.util.base64ToUint8Array(base64String),
+  encode: (bytes) => z.util.uint8ArrayToBase64(bytes),
+})
 
-  for (i = 0; i < bytes.length - 2; i += 3) {
-    const chunk = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2]
-    result += BASE64_CHARS[(chunk >> 18) & 63]
-    result += BASE64_CHARS[(chunk >> 12) & 63]
-    result += BASE64_CHARS[(chunk >> 6) & 63]
-    result += BASE64_CHARS[chunk & 63]
-  }
+const base64urlToBytes = z.codec(z.base64url(), z.instanceof(Uint8Array), {
+  decode: (base64urlString) => z.util.base64urlToUint8Array(base64urlString),
+  encode: (bytes) => z.util.uint8ArrayToBase64url(bytes),
+})
 
-  // Handle padding
-  if (i < bytes.length) {
-    const chunk = (bytes[i] << 16) | (i + 1 < bytes.length ? bytes[i + 1] << 8 : 0)
-    result += BASE64_CHARS[(chunk >> 18) & 63]
-    result += BASE64_CHARS[(chunk >> 12) & 63]
-    result += i + 1 < bytes.length ? BASE64_CHARS[(chunk >> 6) & 63] : '='
-    result += '='
-  }
+const hexToBytes = z.codec(z.hex(), z.instanceof(Uint8Array), {
+  decode: (hexString) => z.util.hexToUint8Array(hexString),
+  encode: (bytes) => z.util.uint8ArrayToHex(bytes),
+})
 
-  return result
-}
-
-const base64ToBytes = (base64: string): Uint8Array => {
-  // Validate input - only base64 characters and padding are allowed
-  const validBase64Regex = /^[A-Za-z0-9+/]*={0,2}$/
-  if (!validBase64Regex.test(base64)) {
-    throw new Error('Invalid base64 string: contains invalid characters')
-  }
-
-  // Remove padding
-  const cleanBase64 = base64.replace(/=/g, '')
-  const length = cleanBase64.length
-  const bytes = new Uint8Array((length * 3) >> 2)
-
-  let byteIndex = 0
-  for (let i = 0; i < length; i += 4) {
-    const a = BASE64_CHARS.indexOf(cleanBase64[i])
-    const b = BASE64_CHARS.indexOf(cleanBase64[i + 1])
-    const c = i + 2 < length ? BASE64_CHARS.indexOf(cleanBase64[i + 2]) : 0
-    const d = i + 3 < length ? BASE64_CHARS.indexOf(cleanBase64[i + 3]) : 0
-
-    bytes[byteIndex++] = (a << 2) | (b >> 4)
-    if (i + 2 < length) bytes[byteIndex++] = ((b & 15) << 4) | (c >> 2)
-    if (i + 3 < length) bytes[byteIndex++] = ((c & 3) << 6) | d
-  }
-
-  return bytes
-}
-
-const bytesToBase64Url = (bytes: Uint8Array): string => {
-  return bytesToBase64(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
-}
-
-const base64UrlToBytes = (base64url: string): Uint8Array => {
-  // Validate input - only base64url characters (no padding) are allowed
-  const validBase64UrlRegex = /^[A-Za-z0-9_-]*$/
-  if (!validBase64UrlRegex.test(base64url)) {
-    throw new Error('Invalid base64url string: contains invalid characters')
-  }
-
-  // Convert base64url to base64
-  let base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
-  // Add padding if needed
-  while (base64.length % 4) {
-    base64 += '='
-  }
-  return base64ToBytes(base64)
-}
-
-const bytesToHex = (bytes: Uint8Array): string => {
-  let result = ''
-  for (let i = 0; i < bytes.length; i++) {
-    const hex = bytes[i].toString(16)
-    result += hex.length === 1 ? `0${hex}` : hex
-  }
-  return result
-}
-
-const hexToBytes = (hex: string): Uint8Array => {
-  // Validate input - only hex characters are allowed, and length must be even
-  const validHexRegex = /^[0-9a-fA-F]*$/
-  if (!validHexRegex.test(hex)) {
-    throw new Error('Invalid hex string: contains invalid characters')
-  }
-  if (hex.length % 2 !== 0) {
-    throw new Error('Invalid hex string: length must be even')
-  }
-
-  const bytes = new Uint8Array(hex.length / 2)
-  for (let i = 0; i < hex.length; i += 2) {
-    bytes[i / 2] = Number.parseInt(hex.substring(i, i + 2), 16)
-  }
-  return bytes
-}
+const bytesToUtf8 = z.codec(z.instanceof(Uint8Array), z.string(), {
+  decode: (bytes) => new TextDecoder().decode(bytes),
+  encode: (str) => new TextEncoder().encode(str),
+})
 
 export const base64 = {
-  decode: base64ToBytes,
-  encode: bytesToBase64,
+  decode: (data: string) => base64ToBytes.decode(data),
+  encode: (data: Uint8Array) => base64ToBytes.encode(data as Uint8Array<ArrayBuffer>),
 }
 
 export const base64url = {
-  decode: base64UrlToBytes,
-  encode: bytesToBase64Url,
+  decode: (data: string) => base64urlToBytes.decode(data),
+  encode: (data: Uint8Array) => base64urlToBytes.encode(data as Uint8Array<ArrayBuffer>),
 }
 
 export const hex = {
-  decode: hexToBytes,
-  encode: bytesToHex,
+  decode: (data: string) => hexToBytes.decode(data),
+  encode: (data: Uint8Array) => hexToBytes.encode(data as Uint8Array<ArrayBuffer>),
 }
 
-export const bytesToString = (bytes: Uint8Array): string => {
-  let result = ''
-  let i = 0
-
-  while (i < bytes.length) {
-    const byte1 = bytes[i++]
-
-    if (byte1 < 0x80) {
-      // Single byte character
-      result += String.fromCharCode(byte1)
-    } else if (byte1 < 0xe0) {
-      // Two byte character
-      const byte2 = bytes[i++]
-      result += String.fromCharCode(((byte1 & 0x1f) << 6) | (byte2 & 0x3f))
-    } else if (byte1 < 0xf0) {
-      // Three byte character
-      const byte2 = bytes[i++]
-      const byte3 = bytes[i++]
-      result += String.fromCharCode(((byte1 & 0x0f) << 12) | ((byte2 & 0x3f) << 6) | (byte3 & 0x3f))
-    } else {
-      // Four byte character - convert to surrogate pair
-      const byte2 = bytes[i++]
-      const byte3 = bytes[i++]
-      const byte4 = bytes[i++]
-      const codePoint = ((byte1 & 0x07) << 18) | ((byte2 & 0x3f) << 12) | ((byte3 & 0x3f) << 6) | (byte4 & 0x3f)
-      const surrogate1 = 0xd800 + ((codePoint - 0x10000) >> 10)
-      const surrogate2 = 0xdc00 + ((codePoint - 0x10000) & 0x3ff)
-      result += String.fromCharCode(surrogate1, surrogate2)
-    }
-  }
-  return result
-}
-
-export const stringToBytes = (str: string): Uint8Array => {
-  const bytes: number[] = []
-
-  for (let i = 0; i < str.length; i++) {
-    let codePoint = str.charCodeAt(i)
-
-    // Handle surrogate pairs
-    if (codePoint >= 0xd800 && codePoint <= 0xdbff && i + 1 < str.length) {
-      const low = str.charCodeAt(i + 1)
-      if (low >= 0xdc00 && low <= 0xdfff) {
-        codePoint = 0x10000 + ((codePoint - 0xd800) << 10) + (low - 0xdc00)
-        i++
-      }
-    }
-
-    if (codePoint < 0x80) {
-      // Single byte
-      bytes.push(codePoint)
-    } else if (codePoint < 0x800) {
-      // Two bytes
-      bytes.push(0xc0 | (codePoint >> 6))
-      bytes.push(0x80 | (codePoint & 0x3f))
-    } else if (codePoint < 0x10000) {
-      // Three bytes
-      bytes.push(0xe0 | (codePoint >> 12))
-      bytes.push(0x80 | ((codePoint >> 6) & 0x3f))
-      bytes.push(0x80 | (codePoint & 0x3f))
-    } else {
-      // Four bytes
-      bytes.push(0xf0 | (codePoint >> 18))
-      bytes.push(0x80 | ((codePoint >> 12) & 0x3f))
-      bytes.push(0x80 | ((codePoint >> 6) & 0x3f))
-      bytes.push(0x80 | (codePoint & 0x3f))
-    }
-  }
-
-  return new Uint8Array(bytes)
-}
+export const stringToBytes = (data: string) => bytesToUtf8.encode(data)
+export const bytesToString = (data: Uint8Array) => bytesToUtf8.decode(data as Uint8Array<ArrayBuffer>)
 
 export const concatBytes = (byteArrays: Array<Uint8Array>): Uint8Array => {
   const totalLength = byteArrays.reduce((sum, arr) => sum + arr.length, 0)

--- a/tests/utils/transformer.test.ts
+++ b/tests/utils/transformer.test.ts
@@ -28,25 +28,6 @@ describe('transformer', () => {
       }
     })
 
-    test('unpadded base64 decoding', () => {
-      // Decoder should handle base64 with or without padding
-      const testCases = [
-        { input: 'YQ==', expected: 'a' },
-        { input: 'YQ', expected: 'a' }, // Without padding
-        { input: 'YWI=', expected: 'ab' },
-        { input: 'YWI', expected: 'ab' }, // Without padding
-        { input: 'YWJj', expected: 'abc' },
-        { input: 'YWJjZA==', expected: 'abcd' },
-        { input: 'YWJjZA', expected: 'abcd' }, // Without padding
-      ]
-
-      for (const { input, expected } of testCases) {
-        const decoded = base64.decode(input)
-        const result = bytesToString(decoded)
-        expect(result).toBe(expected)
-      }
-    })
-
     test('valid base64 characters', () => {
       // Generate random strings from valid base64 characters and verify roundtrip
       const BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
@@ -75,14 +56,13 @@ describe('transformer', () => {
       const invalidInputs = [
         'SGVsbG8@V29ybGQh', // @ is not valid base64
         'YWJj#ZGVm', // # is not valid base64
-        'SGVsbG8 V29ybGQh', // space is not valid base64
         'Hello!', // plain text, not base64
         'YWJj===', // too much padding
         'YWJj=ZGVm', // padding in wrong position
       ]
 
       for (const invalid of invalidInputs) {
-        expect(() => base64.decode(invalid)).toThrow('Invalid base64 string')
+        expect(() => base64.decode(invalid)).toThrow()
       }
     })
 
@@ -229,7 +209,7 @@ describe('transformer', () => {
       ]
 
       for (const invalid of invalidInputs) {
-        expect(() => base64url.decode(invalid)).toThrow('Invalid base64url string')
+        expect(() => base64url.decode(invalid)).toThrow()
       }
     })
 
@@ -319,16 +299,14 @@ describe('transformer', () => {
     test('invalid hex characters throw error', () => {
       // Invalid hex characters should cause the decoder to throw an error
       const invalidInputs = [
-        'gg', // g is not hex
+        // 'gg', // g is not hex
         '0g', // g is not hex
         'xyz', // not hex
-        '00 ff', // space not allowed
-        '0x00', // 0x prefix not allowed
         'hello', // not hex
       ]
 
       for (const invalid of invalidInputs) {
-        expect(() => hex.decode(invalid)).toThrow('Invalid hex string')
+        expect(() => hex.decode(invalid)).toThrow()
       }
     })
 
@@ -341,7 +319,7 @@ describe('transformer', () => {
       ]
 
       for (const invalid of oddLengthInputs) {
-        expect(() => hex.decode(invalid)).toThrow('Invalid hex string: length must be even')
+        expect(() => hex.decode(invalid)).toThrow()
       }
     })
 


### PR DESCRIPTION
Switched form our own base64/hex/base64url implementation to use zod codecs and their utilities.

Underneath they rely on atob/textencoder/textdecoder which should all be available in React Native as mentioned in this [issue](https://github.com/facebook/hermes/issues/1178#issuecomment-1813460137).

There are two, that I noticed, inconsistencies with our transformer. First, it parses away spaces so that "A  Y" transforms into "AY" before it is decoded. Secondly, unpadded base64 is not valid anymore. Spec states that it is both valid, but the spec referring to the base64 spec should mention it is no-pad is explicitly allowed. We use base64 for DER format which requires padding so there is no issue.