### PR TITLE
chore: export limit disclosure

### DIFF
--- a/.changeset/curvy-suits-poke.md
+++ b/.changeset/curvy-suits-poke.md
@@ -1,0 +1,5 @@
+---
+"@owf/mdoc": patch
+---
+
+- Export the method to limit the disclosures so it can be used by the user without requiring them to set/create a signature

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 export { cborDecode, cborEncode, DataItem, DateOnly } from './cbor'
-
 export * from './context'
 export * from './cose'
 export * from './holder'
 export * from './issuer'
 export * from './mdoc'
 export * from './utils'
+export { limitDisclosureToDeviceRequestNameSpaces } from './utils/limitDisclosure'
 export * from './verifier'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,2 @@
 export * from './transformers'
 export * from './typed-map'
-
-export {limitDisclosureToDeviceRequestNameSpaces} from './limitDisclosure'


### PR DESCRIPTION
- **chore: export limit disclosure**
- **docs(changeset): - Export the method to limit the disclosures so it can be used by the user without requiring them to set/create a signature**
