### PR TITLE
feat: add IsoMdocDcApiHandover for ISO 18013-7 Annex C

### DIFF
--- a/.changeset/silent-foxes-wander.md
+++ b/.changeset/silent-foxes-wander.md
@@ -1,0 +1,5 @@
+---
+"@owf/mdoc": minor
+---
+
+feat: add `IsoMdocDcApiHandover` for the ISO 18013-7 Annex C `org-iso-mdoc` DC API protocol, with a `SessionTranscript.forIsoMdocDcApi` factory. Shape: `[ "dcapi", SHA-256(CBOR([encInfoB64u, origin])) ]`. Distinct from the OpenID4VP DC API handover; needed when verifying responses from a wallet that answered an `org-iso-mdoc` request (the only protocol Safari on iOS 26 supports).

--- a/src/mdoc/models/iso-mdoc-dc-api-handover.ts
+++ b/src/mdoc/models/iso-mdoc-dc-api-handover.ts
@@ -1,0 +1,45 @@
+import { cborEncode, zUint8Array } from '@owf/cose'
+import z from 'zod'
+import type { MdocContext } from '../../context'
+import { Handover } from './handover'
+
+const isoMdocDcApiHandoverEncodedSchema = z.tuple([z.literal('dcapi'), zUint8Array])
+const isoMdocDcApiHandoverDecodedSchema = zUint8Array
+
+export type IsoMdocDcApiHandoverEncodedStructure = z.infer<typeof isoMdocDcApiHandoverEncodedSchema>
+export type IsoMdocDcApiHandoverDecodedStructure = z.infer<typeof isoMdocDcApiHandoverDecodedSchema>
+
+export type IsoMdocDcApiHandoverOptions = {
+  encryptionInfoBase64Url: string
+  origin: string
+}
+
+/**
+ * Handover for the ISO 18013-7 Annex C `org-iso-mdoc` DC API protocol.
+ *
+ *   DCAPIHandover = [ "dcapi", SHA-256(CBOR([encInfoB64u, origin])) ]
+ */
+export class IsoMdocDcApiHandover extends Handover<
+  IsoMdocDcApiHandoverEncodedStructure,
+  IsoMdocDcApiHandoverDecodedStructure
+> {
+  public static override get encodingSchema() {
+    return z.codec(isoMdocDcApiHandoverEncodedSchema, isoMdocDcApiHandoverDecodedSchema, {
+      encode: (handoverInfoHash) => ['dcapi', handoverInfoHash] satisfies IsoMdocDcApiHandoverEncodedStructure,
+      decode: ([, handoverInfoHash]) => handoverInfoHash,
+    })
+  }
+
+  public static createFromHash(dcApiInfoHash: Uint8Array) {
+    return this.fromDecodedStructure(dcApiInfoHash)
+  }
+
+  public static async create(options: IsoMdocDcApiHandoverOptions, ctx: Pick<MdocContext, 'crypto'>) {
+    const dcapiInfoBytes = cborEncode([options.encryptionInfoBase64Url, options.origin])
+    const dcApiInfoHash = await ctx.crypto.digest({
+      digestAlgorithm: 'SHA-256',
+      bytes: dcapiInfoBytes,
+    })
+    return this.fromDecodedStructure(dcApiInfoHash)
+  }
+}

--- a/src/mdoc/models/session-transcript.ts
+++ b/src/mdoc/models/session-transcript.ts
@@ -4,6 +4,7 @@ import type { MdocContext } from '../../context'
 import { DeviceEngagement, type DeviceEngagementEncodedStructure } from './device-engagement'
 import { EReaderKey, type EReaderKeyEncodedStructure } from './e-reader-key'
 import { Handover } from './handover'
+import { IsoMdocDcApiHandover, type IsoMdocDcApiHandoverOptions } from './iso-mdoc-dc-api-handover'
 import { NfcHandover } from './nfc-handover'
 import {
   Oid4vpDcApiDraft24HandoverInfo,
@@ -21,6 +22,7 @@ import { QrHandover } from './qr-handover'
 const supportedHandoverStructures = [
   Oid4vpHandover,
   Oid4vpDcApiHandover,
+  IsoMdocDcApiHandover,
   Oid4vpIaeHandover,
   NfcHandover,
   QrHandover,
@@ -161,6 +163,15 @@ export class SessionTranscript extends CborStructure<
     const info = Oid4vpDcApiHandoverInfo.create(options)
     const handover = await Oid4vpDcApiHandover.create({ oid4vpDcApiHandoverInfo: info }, ctx)
 
+    return this.fromDecodedStructure({ deviceEngagement: null, eReaderKey: null, handover })
+  }
+
+  /**
+   * Create a SessionTranscript for the ISO 18013-7 Annex C
+   * `org-iso-mdoc` DC API protocol.
+   */
+  public static async forIsoMdocDcApi(options: IsoMdocDcApiHandoverOptions, ctx: Pick<MdocContext, 'crypto'>) {
+    const handover = await IsoMdocDcApiHandover.create(options, ctx)
     return this.fromDecodedStructure({ deviceEngagement: null, eReaderKey: null, handover })
   }
 


### PR DESCRIPTION
Adds the `org-iso-mdoc` DC API handover variant alongside the OpenID4VP DC API handover. Shape per ISO 18013-7 Annex C:

```
DCAPIHandover = [ "dcapi", SHA-256(CBOR([encInfoB64u, origin])) ]
```

Exposes `SessionTranscript.forIsoMdocDcApi(options, ctx)` parallel to `forOid4VpDcApi`.