### PR TITLE
refactor: inline x509 context types in MdocContext

### DIFF
--- a/.changeset/calm-rabbits-listen.md
+++ b/.changeset/calm-rabbits-listen.md
@@ -1,0 +1,5 @@
+---
+"@owf/mdoc": patch
+---
+
+refactor: inline the `getIssuerNameField` / `getPublicKey` signatures in `MdocContext['x509']` instead of indexing into `Sign1Context['x509']`. Decouples `MdocContext` from `@owf/cose`'s internal layout, so the upcoming cose bumps (#197, #198, #200) don't silently drop the parameter types on every downstream `MdocContext` implementation when `Sign1Context['x509']` goes away. Behaviour and shape stay identical.

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import type { DigestAlgorithm, Mac0Context, Sign1Context } from '@owf/cose'
+import type { CoseKey, DigestAlgorithm, Mac0Context, Sign1Context, SignatureAlgorithm } from '@owf/cose'
 
 type MaybePromise<T> = Promise<T> | T
 
@@ -26,9 +26,9 @@ export interface MdocContext {
   }
 
   x509: {
-    getIssuerNameField: Sign1Context['x509']['getIssuerNameField']
+    getIssuerNameField: (options: { certificate: Uint8Array; field: string }) => string[]
 
-    getPublicKey: Sign1Context['x509']['getPublicKey']
+    getPublicKey: (options: { certificate: Uint8Array; algorithm?: SignatureAlgorithm }) => Promise<CoseKey>
 
     verifyCertificateChain: (input: {
       trustedCertificates: Uint8Array[]


### PR DESCRIPTION
`MdocContext['x509']` referenced `Sign1Context['x509']['getIssuerNameField']` / `Sign1Context['x509']['getPublicKey']`, which ties our public context interface to cose's internal organisation. The open `@owf/cose` dependabot bump (#198) moves cose to a version where `Sign1Context` loses its `x509` sub-context, at which point every `MdocContext` implementor silently loses the parameter types on `getIssuerNameField` / `getPublicKey` (TS doesn't error on indexed access into a missing property; it resolves to `any`).

Inlining the two signatures lets `MdocContext` stand on its own. Behaviour and shape are unchanged, the change lands cleanly on current `main` (`Sign1Context['x509']` still resolves there), and once merged the type breakage from #198 is contained to the parallel-cose-version issue, which is resolved when #197 / #200 land in lock-step.