### PR TITLE
feat!: trusted certificates is a list of lists and may contain a status certificate

### DIFF
--- a/.changeset/old-trains-spend.md
+++ b/.changeset/old-trains-spend.md
@@ -1,0 +1,5 @@
+---
+"@owf/mdoc": minor
+---
+
+`trustedCertificates` now has been changed into an array of objects. Where each entry contains `{issuance: Uint8Array[], status?: Uint8Array[]}`. To migrate, use `const newtrustedCertificates = [{issuance: oldTrustedCertificates}]`

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@owf/cose": "0.3.0-alpha-20260601075923",
     "@owf/identity-common": "0.3.0-alpha-20260601075923",
     "@owf/token-status-list": "0.3.0-alpha-20260601075923",
+    "@peculiar/x509": "^1.14.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -39,7 +40,6 @@
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@panva/hkdf": "^1.2.1",
-    "@peculiar/x509": "^1.14.3",
     "@types/node": "^25.5.0",
     "jose": "^6.2.2",
     "tsdown": "^0.21.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@owf/cose": "0.3.0-alpha-20260601075923",
     "@owf/identity-common": "0.3.0-alpha-20260601075923",
     "@owf/token-status-list": "0.3.0-alpha-20260601075923",
-    "@peculiar/x509": "^1.14.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -39,6 +38,7 @@
     "@changesets/cli": "^2.30.0",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
+    "@peculiar/x509": "^1.14.3",
     "@panva/hkdf": "^1.2.1",
     "@types/node": "^25.5.0",
     "jose": "^6.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@owf/token-status-list':
         specifier: 0.3.0-alpha-20260601075923
         version: 0.3.0-alpha-20260601075923
+      '@peculiar/x509':
+        specifier: ^1.14.3
+        version: 1.14.3
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -36,9 +39,6 @@ importers:
       '@panva/hkdf':
         specifier: ^1.2.1
         version: 1.2.1
-      '@peculiar/x509':
-        specifier: ^1.14.3
-        version: 1.14.3
       '@types/node':
         specifier: ^25.5.0
         version: 25.9.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@owf/token-status-list':
         specifier: 0.3.0-alpha-20260601075923
         version: 0.3.0-alpha-20260601075923
-      '@peculiar/x509':
-        specifier: ^1.14.3
-        version: 1.14.3
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -39,6 +36,9 @@ importers:
       '@panva/hkdf':
         specifier: ^1.2.1
         version: 1.2.1
+      '@peculiar/x509':
+        specifier: ^1.14.3
+        version: 1.14.3
       '@types/node':
         specifier: ^25.5.0
         version: 25.9.1

--- a/src/context.ts
+++ b/src/context.ts
@@ -32,11 +32,18 @@ export interface MdocContext {
       algorithm?: SignatureAlgorithm | MacAlgorithm
     }) => Promise<CoseKey>
 
+    /**
+     *
+     * Verify a X.509 certificate chain
+     *
+     * Return the parsed chain where index 0 is the leaf certificate and the last entry is the X.509 certificate found in the trusted certificates (root)
+     *
+     */
     verifyCertificateChain: (input: {
       trustedCertificates: Uint8Array[]
       x5chain: Uint8Array[]
       now?: Date
-    }) => MaybePromise<void>
+    }) => MaybePromise<{ chain: Uint8Array[] }>
 
     getCertificateData: (input: { certificate: Uint8Array }) => MaybePromise<{
       issuerName: string

--- a/src/holder.ts
+++ b/src/holder.ts
@@ -27,7 +27,7 @@ export class Holder {
       skewSeconds?: number
     },
     ctx: Pick<MdocContext, 'cose' | 'x509' | 'crypto' | 'fetch'>
-  ): Promise<{ issuanceCertificate: Uint8Array; statusCertificate?: Uint8Array }> {
+  ): Promise<{ trustedIssuanceCertificate: Uint8Array; trustedStatusCertificate?: Uint8Array }> {
     const issuerSigned =
       typeof options.issuerSigned === 'string'
         ? IssuerSigned.decode(base64url.decode(options.issuerSigned))

--- a/src/holder.ts
+++ b/src/holder.ts
@@ -5,6 +5,7 @@ import {
   type DeviceNamespaces,
   DeviceRequest,
   DeviceResponse,
+  type GetTrustedStatusCertificates,
   IssuerSigned,
   SessionTranscript,
   type VerificationCallback,
@@ -24,7 +25,7 @@ export class Holder {
       disableCertificateChainValidation?: boolean
       disableStatusValidation?: boolean
       trustedCertificates?: Array<Uint8Array>
-      trustedStatusCertificates?: Array<Uint8Array>
+      getTrustedStatusCertificates?: GetTrustedStatusCertificates
       skewSeconds?: number
     },
     ctx: Pick<MdocContext, 'cose' | 'x509' | 'crypto' | 'fetch'>

--- a/src/holder.ts
+++ b/src/holder.ts
@@ -5,7 +5,6 @@ import {
   type DeviceNamespaces,
   DeviceRequest,
   DeviceResponse,
-  type GetTrustedStatusCertificates,
   IssuerSigned,
   SessionTranscript,
   type VerificationCallback,
@@ -24,12 +23,11 @@ export class Holder {
       now?: Date
       disableCertificateChainValidation?: boolean
       disableStatusValidation?: boolean
-      trustedCertificates?: Array<Uint8Array>
-      getTrustedStatusCertificates?: GetTrustedStatusCertificates
+      trustedCertificates?: Array<{ issuance: Uint8Array[]; status?: Uint8Array[] }>
       skewSeconds?: number
     },
     ctx: Pick<MdocContext, 'cose' | 'x509' | 'crypto' | 'fetch'>
-  ) {
+  ): Promise<{ issuanceCertificate: Uint8Array; statusCertificate?: Uint8Array }> {
     const issuerSigned =
       typeof options.issuerSigned === 'string'
         ? IssuerSigned.decode(base64url.decode(options.issuerSigned))
@@ -37,7 +35,7 @@ export class Holder {
           ? IssuerSigned.decode(options.issuerSigned)
           : options.issuerSigned
 
-    await issuerSigned.verify(options, ctx)
+    return await issuerSigned.verify(options, ctx)
   }
 
   public static async verifyDeviceRequest(

--- a/src/mdoc/errors.ts
+++ b/src/mdoc/errors.ts
@@ -6,10 +6,6 @@ export class MdlError extends Error {
 }
 
 export class MdlParseError extends MdlError {}
-export class PresentationDefinitionOrDocRequestsAreRequiredError extends MdlError {}
-export class SessionTranscriptOrSessionTranscriptBytesAreRequiredError extends MdlError {}
-export class DuplicateNamespaceInIssuerNamespacesError extends MdlError {}
-export class DuplicateDocumentInDeviceResponseError extends MdlError {}
 export class EitherSignatureOrMacMustBeProvidedError extends MdlError {}
 export class AtLeastOneCertificateRequiredError extends MdlError {}
 export class SignatureAlgorithmDoesNotMatchSigningKeyAlgorithmError extends MdlError {}
@@ -20,4 +16,3 @@ export class InvalidMessageAuthenticationCode extends MdlError {}
 export class InvalidSignatureError extends MdlError {}
 export class JwtNotSupportForStatusListError extends MdlError {}
 export class TrustedRevocationCertificatesMustContainAtleastOneCertificateError extends MdlError {}
-export class NoGetTrustedStatusCertificatesDefinedError extends MdlError {}

--- a/src/mdoc/errors.ts
+++ b/src/mdoc/errors.ts
@@ -20,3 +20,4 @@ export class InvalidMessageAuthenticationCode extends MdlError {}
 export class InvalidSignatureError extends MdlError {}
 export class JwtNotSupportForStatusListError extends MdlError {}
 export class TrustedRevocationCertificatesMustContainAtleastOneCertificateError extends MdlError {}
+export class NoGetTrustedStatusCertificatesDefinedError extends MdlError {}

--- a/src/mdoc/models/device-response.ts
+++ b/src/mdoc/models/device-response.ts
@@ -24,7 +24,6 @@ import { DeviceSignature } from './device-signature'
 import { DeviceSigned } from './device-signed'
 import { Document, type DocumentEncodedStructure } from './document'
 import { DocumentError, type DocumentErrorStructure } from './document-error'
-import type { GetTrustedStatusCertificates } from './issuer-auth'
 import { IssuerSigned } from './issuer-signed'
 import type { SessionTranscript } from './session-transcript'
 
@@ -125,14 +124,13 @@ export class DeviceResponse extends CborStructure<DeviceResponseEncodedStructure
       ephemeralReaderKey?: CoseKey
       disableCertificateChainValidation?: boolean
       disableStatusValidation?: boolean
-      trustedCertificates: Uint8Array[]
-      getTrustedStatusCertificates?: GetTrustedStatusCertificates
+      trustedCertificates: Array<{ issuance: Uint8Array[]; status?: Uint8Array[] }>
       now?: Date
       onCheck?: VerificationCallback
       skewSeconds?: number
     },
     ctx: Pick<MdocContext, 'cose' | 'x509' | 'crypto' | 'fetch'>
-  ) {
+  ): Promise<{ issuanceCertificate: Uint8Array; statusCertificate?: Uint8Array } | undefined> {
     const onCheck = options.onCheck ?? defaultVerificationCallback
 
     const version = this.structure.get('version')
@@ -149,6 +147,7 @@ export class DeviceResponse extends CborStructure<DeviceResponseEncodedStructure
       category: 'DOCUMENT_FORMAT',
     })
 
+    let usedCertificates: { issuanceCertificate: Uint8Array; statusCertificate?: Uint8Array } | undefined
     for (const document of documents ?? []) {
       await document.deviceSigned.deviceAuth.verify(
         {
@@ -160,7 +159,7 @@ export class DeviceResponse extends CborStructure<DeviceResponseEncodedStructure
         ctx
       )
 
-      await document.issuerSigned.verify(
+      usedCertificates = await document.issuerSigned.verify(
         {
           verificationCallback: onCheck,
           disableCertificateChainValidation: options.disableCertificateChainValidation,
@@ -168,7 +167,6 @@ export class DeviceResponse extends CborStructure<DeviceResponseEncodedStructure
           trustedCertificates: options.trustedCertificates,
           skewSeconds: options.skewSeconds,
           disableStatusValidation: options.disableStatusValidation,
-          getTrustedStatusCertificates: options.getTrustedStatusCertificates,
         },
         ctx
       )
@@ -193,6 +191,8 @@ export class DeviceResponse extends CborStructure<DeviceResponseEncodedStructure
         })
       }
     }
+
+    return usedCertificates
   }
 
   public get encodedForOid4Vp() {

--- a/src/mdoc/models/device-response.ts
+++ b/src/mdoc/models/device-response.ts
@@ -130,7 +130,7 @@ export class DeviceResponse extends CborStructure<DeviceResponseEncodedStructure
       skewSeconds?: number
     },
     ctx: Pick<MdocContext, 'cose' | 'x509' | 'crypto' | 'fetch'>
-  ): Promise<{ issuanceCertificate: Uint8Array; statusCertificate?: Uint8Array } | undefined> {
+  ): Promise<{ trustedIssuanceCertificate: Uint8Array; trustedStatusCertificate?: Uint8Array } | undefined> {
     const onCheck = options.onCheck ?? defaultVerificationCallback
 
     const version = this.structure.get('version')
@@ -147,7 +147,7 @@ export class DeviceResponse extends CborStructure<DeviceResponseEncodedStructure
       category: 'DOCUMENT_FORMAT',
     })
 
-    let usedCertificates: { issuanceCertificate: Uint8Array; statusCertificate?: Uint8Array } | undefined
+    let usedCertificates: { trustedIssuanceCertificate: Uint8Array; trustedStatusCertificate?: Uint8Array } | undefined
     for (const document of documents ?? []) {
       await document.deviceSigned.deviceAuth.verify(
         {

--- a/src/mdoc/models/device-response.ts
+++ b/src/mdoc/models/device-response.ts
@@ -24,6 +24,7 @@ import { DeviceSignature } from './device-signature'
 import { DeviceSigned } from './device-signed'
 import { Document, type DocumentEncodedStructure } from './document'
 import { DocumentError, type DocumentErrorStructure } from './document-error'
+import type { GetTrustedStatusCertificates } from './issuer-auth'
 import { IssuerSigned } from './issuer-signed'
 import type { SessionTranscript } from './session-transcript'
 
@@ -125,7 +126,7 @@ export class DeviceResponse extends CborStructure<DeviceResponseEncodedStructure
       disableCertificateChainValidation?: boolean
       disableStatusValidation?: boolean
       trustedCertificates: Uint8Array[]
-      trustedStatusCertificates?: Uint8Array[]
+      getTrustedStatusCertificates?: GetTrustedStatusCertificates
       now?: Date
       onCheck?: VerificationCallback
       skewSeconds?: number
@@ -167,7 +168,7 @@ export class DeviceResponse extends CborStructure<DeviceResponseEncodedStructure
           trustedCertificates: options.trustedCertificates,
           skewSeconds: options.skewSeconds,
           disableStatusValidation: options.disableStatusValidation,
-          trustedStatusCertificates: options.trustedStatusCertificates,
+          getTrustedStatusCertificates: options.getTrustedStatusCertificates,
         },
         ctx
       )

--- a/src/mdoc/models/issuer-auth.ts
+++ b/src/mdoc/models/issuer-auth.ts
@@ -30,6 +30,10 @@ export type IssuerAuthOptions = Omit<Sign1Options, 'payload'> & {
   payload?: Sign1Options['payload'] | MobileSecurityObject
 }
 
+export type GetTrustedStatusCertificates = (options: {
+  statusListCertificateChain?: Array<Uint8Array>
+}) => Promise<{ trustedStatusListCertificateChain?: Array<Uint8Array> }>
+
 export class IssuerAuth extends Sign1 {
   public static create(options: IssuerAuthOptions): IssuerAuth {
     return super.create({
@@ -89,8 +93,12 @@ export class IssuerAuth extends Sign1 {
     {
       now = new Date(),
       checkFreshness,
-      trustedStatusCertificates,
-    }: { now?: Date; checkFreshness?: boolean; trustedStatusCertificates: Array<Uint8Array> },
+      getTrustedStatusCertificates,
+    }: {
+      now?: Date
+      checkFreshness?: boolean
+      getTrustedStatusCertificates?: GetTrustedStatusCertificates
+    },
     ctx: Pick<MdocContext, 'fetch' | 'x509' | 'cose'>
   ) {
     if (!this.mobileSecurityObject.status) return undefined
@@ -121,7 +129,7 @@ export class IssuerAuth extends Sign1 {
       throw new UnableToExtractX5ChainFromCwtError()
     }
 
-    const algorithm = this.protectedHeaders.headers?.get(RegisteredCwtHeaderClaimKey.Algorithm) as SignatureAlgorithm
+    const algorithm = cwt.protectedHeaders?.headers.get(RegisteredCwtHeaderClaimKey.Algorithm) as SignatureAlgorithm
     const x5chain =
       x5c instanceof Uint8Array
         ? [x5c]
@@ -135,13 +143,18 @@ export class IssuerAuth extends Sign1 {
 
     const [certificate] = x5chain
 
-    if (trustedStatusCertificates.length === 0) {
+    const trustedStatusCertificates = await getTrustedStatusCertificates?.({ statusListCertificateChain: x5chain })
+
+    if (!trustedStatusCertificates || trustedStatusCertificates.trustedStatusListCertificateChain?.length === 0) {
       throw new TrustedRevocationCertificatesMustContainAtleastOneCertificateError(
-        'Atleast one certificate is required to check the status of the mdoc. Make sure to provide it in the `trustedStatusCertificates`'
+        'Atleast one certificate is required to check the status of the mdoc. Make sure the `getTrustedStatusCertificates` callback is correctly imlpemented.'
       )
     }
 
-    await ctx.x509.verifyCertificateChain({ trustedCertificates: trustedStatusCertificates, x5chain })
+    await ctx.x509.verifyCertificateChain({
+      trustedCertificates: trustedStatusCertificates.trustedStatusListCertificateChain as Array<Uint8Array>,
+      x5chain,
+    })
 
     const publicKey = await ctx.x509.getPublicKey({ certificate, algorithm })
     const alg = algorithm ?? publicKey.algorithm
@@ -174,7 +187,7 @@ export class IssuerAuth extends Sign1 {
       verificationCallback?: VerificationCallback
       now?: Date
       trustedCertificates?: Array<Uint8Array>
-      trustedStatusCertificates?: Array<Uint8Array>
+      getTrustedStatusCertificates?: GetTrustedStatusCertificates
       disableCertificateChainValidation?: boolean
       disableStatusValidation?: boolean
       skewSeconds?: number
@@ -186,7 +199,6 @@ export class IssuerAuth extends Sign1 {
     const disableCertificateChainValidation = options.disableCertificateChainValidation ?? false
     const disableStatusValidation = options.disableStatusValidation ?? false
     const trustedCertificates = options.trustedCertificates ?? []
-    const trustedStatusCertificates = options.trustedStatusCertificates ?? []
     const skewSeconds = options.skewSeconds ?? 30
 
     const onCheck = onCategoryCheck(verificationCallback, 'ISSUER_AUTH')
@@ -227,7 +239,7 @@ export class IssuerAuth extends Sign1 {
           {
             now,
             checkFreshness: true,
-            trustedStatusCertificates,
+            getTrustedStatusCertificates: options.getTrustedStatusCertificates,
           },
           ctx
         )

--- a/src/mdoc/models/issuer-auth.ts
+++ b/src/mdoc/models/issuer-auth.ts
@@ -11,6 +11,7 @@ import {
   zUint8Array,
 } from '@owf/cose'
 import { fetchStatusList, StatusListCwt } from '@owf/token-status-list'
+import { X509Certificate } from '@peculiar/x509'
 import z from 'zod'
 import type { MdocContext } from '../../context.js'
 import { defaultVerificationCallback, onCategoryCheck, type VerificationCallback } from '../check-callback.js'
@@ -29,10 +30,6 @@ export type IssuerAuthEncodedStructure = Sign1EncodedStructure
 export type IssuerAuthOptions = Omit<Sign1Options, 'payload'> & {
   payload?: Sign1Options['payload'] | MobileSecurityObject
 }
-
-export type GetTrustedStatusCertificates = (options: {
-  statusListCertificateChain?: Array<Uint8Array>
-}) => Promise<{ trustedStatusListCertificateChain?: Array<Uint8Array> }>
 
 export class IssuerAuth extends Sign1 {
   public static create(options: IssuerAuthOptions): IssuerAuth {
@@ -93,14 +90,14 @@ export class IssuerAuth extends Sign1 {
     {
       now = new Date(),
       checkFreshness,
-      getTrustedStatusCertificates,
+      trustedStatusCertificates,
     }: {
       now?: Date
       checkFreshness?: boolean
-      getTrustedStatusCertificates?: GetTrustedStatusCertificates
+      trustedStatusCertificates?: Uint8Array[]
     },
     ctx: Pick<MdocContext, 'fetch' | 'x509' | 'cose'>
-  ) {
+  ): Promise<Uint8Array | undefined> {
     if (!this.mobileSecurityObject.status) return undefined
     if (!this.mobileSecurityObject.status.statusList) return undefined
     if (this.mobileSecurityObject.status.identifierList) {
@@ -143,16 +140,14 @@ export class IssuerAuth extends Sign1 {
 
     const [certificate] = x5chain
 
-    const trustedStatusCertificates = await getTrustedStatusCertificates?.({ statusListCertificateChain: x5chain })
-
-    if (!trustedStatusCertificates || trustedStatusCertificates.trustedStatusListCertificateChain?.length === 0) {
+    if (!trustedStatusCertificates || trustedStatusCertificates.length <= 0) {
       throw new TrustedRevocationCertificatesMustContainAtleastOneCertificateError(
-        'Atleast one certificate is required to check the status of the mdoc. Make sure the `getTrustedStatusCertificates` callback is correctly imlpemented.'
+        'Atleast one certificate is required to check the status of the mdoc. Make sure to supply them in the `trustedStatusCertificates` option'
       )
     }
 
     await ctx.x509.verifyCertificateChain({
-      trustedCertificates: trustedStatusCertificates.trustedStatusListCertificateChain as Array<Uint8Array>,
+      trustedCertificates: trustedStatusCertificates,
       x5chain,
     })
 
@@ -179,21 +174,20 @@ export class IssuerAuth extends Sign1 {
     }
 
     cwt.verifyStatus({ uri, idx, now, checkFreshness })
-    return true
+    return certificate
   }
 
   public async verify(
     options: {
       verificationCallback?: VerificationCallback
       now?: Date
-      trustedCertificates?: Array<Uint8Array>
-      getTrustedStatusCertificates?: GetTrustedStatusCertificates
+      trustedCertificates?: Array<{ issuance: Uint8Array[]; status?: Uint8Array[] }>
       disableCertificateChainValidation?: boolean
       disableStatusValidation?: boolean
       skewSeconds?: number
     },
     ctx: Pick<MdocContext, 'x509' | 'cose' | 'fetch'>
-  ) {
+  ): Promise<{ issuanceCertificate: Uint8Array; statusCertificate?: Uint8Array }> {
     const verificationCallback = options.verificationCallback ?? defaultVerificationCallback
     const now = options.now ?? new Date()
     const disableCertificateChainValidation = options.disableCertificateChainValidation ?? false
@@ -208,17 +202,20 @@ export class IssuerAuth extends Sign1 {
       check: "Country name (C) must be present in the issuer certificate's subject distinguished name",
     })
 
+    let chain: Uint8Array[]
     if (!disableCertificateChainValidation) {
       try {
-        if (!trustedCertificates[0]) {
+        if (!trustedCertificates || trustedCertificates?.length <= 0) {
           throw new Error('No trusted certificates found. Cannot verify issuer signature.')
         }
 
-        await ctx.x509.verifyCertificateChain({
-          trustedCertificates,
-          x5chain: this.certificateChain,
-          now,
-        })
+        chain = (
+          await ctx.x509.verifyCertificateChain({
+            trustedCertificates: trustedCertificates.flatMap(({ issuance }) => issuance),
+            x5chain: this.certificateChain,
+            now,
+          })
+        ).chain
 
         onCheck({
           status: 'PASSED',
@@ -233,13 +230,17 @@ export class IssuerAuth extends Sign1 {
       }
     }
 
+    let statusCertificate: Uint8Array | undefined
     if (!disableStatusValidation) {
       try {
-        await this.verifyStatus(
+        const trustedStatusCertificates = trustedCertificates.find((tc) =>
+          tc.issuance.map((cert) => new X509Certificate(cert).equal(chain[chain.length - 1]))
+        )?.status
+        statusCertificate = await this.verifyStatus(
           {
             now,
             checkFreshness: true,
-            getTrustedStatusCertificates: options.getTrustedStatusCertificates,
+            trustedStatusCertificates,
           },
           ctx
         )
@@ -280,5 +281,7 @@ export class IssuerAuth extends Sign1 {
       check: 'The MSO must be valid at the time of verification',
       reason: `The MSO must be valid at the time of verification (${now.toUTCString()})`,
     })
+
+    return { issuanceCertificate: this.certificate, statusCertificate }
   }
 }

--- a/src/mdoc/models/issuer-auth.ts
+++ b/src/mdoc/models/issuer-auth.ts
@@ -10,8 +10,8 @@ import {
   SignatureAlgorithm,
   zUint8Array,
 } from '@owf/cose'
+import { compareBytes } from '@owf/identity-common'
 import { fetchStatusList, StatusListCwt } from '@owf/token-status-list'
-import { X509Certificate } from '@peculiar/x509'
 import z from 'zod'
 import type { MdocContext } from '../../context.js'
 import { defaultVerificationCallback, onCategoryCheck, type VerificationCallback } from '../check-callback.js'
@@ -187,7 +187,7 @@ export class IssuerAuth extends Sign1 {
       skewSeconds?: number
     },
     ctx: Pick<MdocContext, 'x509' | 'cose' | 'fetch'>
-  ): Promise<{ issuanceCertificate: Uint8Array; statusCertificate?: Uint8Array }> {
+  ): Promise<{ trustedIssuanceCertificate: Uint8Array; trustedStatusCertificate?: Uint8Array }> {
     const verificationCallback = options.verificationCallback ?? defaultVerificationCallback
     const now = options.now ?? new Date()
     const disableCertificateChainValidation = options.disableCertificateChainValidation ?? false
@@ -202,20 +202,23 @@ export class IssuerAuth extends Sign1 {
       check: "Country name (C) must be present in the issuer certificate's subject distinguished name",
     })
 
-    let chain: Uint8Array[]
+    let trustedStatusCertificates: Uint8Array[] | undefined
     if (!disableCertificateChainValidation) {
       try {
         if (!trustedCertificates || trustedCertificates?.length <= 0) {
           throw new Error('No trusted certificates found. Cannot verify issuer signature.')
         }
 
-        chain = (
-          await ctx.x509.verifyCertificateChain({
-            trustedCertificates: trustedCertificates.flatMap(({ issuance }) => issuance),
-            x5chain: this.certificateChain,
-            now,
-          })
-        ).chain
+        const { chain } = await ctx.x509.verifyCertificateChain({
+          trustedCertificates: trustedCertificates.flatMap(({ issuance }) => issuance),
+          x5chain: this.certificateChain,
+          now,
+        })
+
+        trustedStatusCertificates = chain[chain.length - 1]
+          ? trustedCertificates.find((tc) => tc.issuance.map((cert) => compareBytes(cert, chain[chain.length - 1])))
+              ?.status
+          : undefined
 
         onCheck({
           status: 'PASSED',
@@ -230,13 +233,10 @@ export class IssuerAuth extends Sign1 {
       }
     }
 
-    let statusCertificate: Uint8Array | undefined
+    let trustedStatusCertificate: Uint8Array | undefined
     if (!disableStatusValidation) {
       try {
-        const trustedStatusCertificates = trustedCertificates.find((tc) =>
-          tc.issuance.map((cert) => new X509Certificate(cert).equal(chain[chain.length - 1]))
-        )?.status
-        statusCertificate = await this.verifyStatus(
+        trustedStatusCertificate = await this.verifyStatus(
           {
             now,
             checkFreshness: true,
@@ -247,14 +247,14 @@ export class IssuerAuth extends Sign1 {
       } catch (err) {
         onCheck({
           status: 'FAILED',
-          check: 'Revocation information must be valid',
+          check: 'Status information must be valid',
           reason: err instanceof Error ? err.message : 'Unknown error',
         })
       }
     }
 
     const publicKey = await ctx.x509.getPublicKey({ certificate: this.certificate, algorithm: this.algorithm })
-    const isSignatureValid = await this.verifySignature({ key: publicKey }, { verify: ctx.cose.sign1.verify })
+    const isSignatureValid = await this.verifySignature({ key: publicKey }, ctx.cose.sign1)
 
     onCheck({
       status: isSignatureValid ? 'PASSED' : 'FAILED',
@@ -282,6 +282,6 @@ export class IssuerAuth extends Sign1 {
       reason: `The MSO must be valid at the time of verification (${now.toUTCString()})`,
     })
 
-    return { issuanceCertificate: this.certificate, statusCertificate }
+    return { trustedIssuanceCertificate: this.certificate, trustedStatusCertificate }
   }
 }

--- a/src/mdoc/models/issuer-signed.ts
+++ b/src/mdoc/models/issuer-signed.ts
@@ -85,7 +85,7 @@ export class IssuerSigned extends CborStructure<IssuerSignedEncodedStructure, Is
       skewSeconds?: number
     },
     ctx: Pick<MdocContext, 'x509' | 'crypto' | 'cose' | 'fetch'>
-  ): Promise<{ issuanceCertificate: Uint8Array; statusCertificate?: Uint8Array }> {
+  ): Promise<{ trustedIssuanceCertificate: Uint8Array; trustedStatusCertificate?: Uint8Array }> {
     const { valueDigests, digestAlgorithm } = this.issuerAuth.mobileSecurityObject
 
     const onCheck = onCategoryCheck(options.verificationCallback ?? defaultVerificationCallback, 'DATA_INTEGRITY')
@@ -96,7 +96,7 @@ export class IssuerSigned extends CborStructure<IssuerSignedEncodedStructure, Is
     })
 
     // Verify the issuer auth
-    const { issuanceCertificate, statusCertificate } = await this.issuerAuth.verify(options, ctx)
+    const { trustedIssuanceCertificate, trustedStatusCertificate } = await this.issuerAuth.verify(options, ctx)
 
     const namespaces = this.issuerNamespaces?.issuerNamespaces ?? new Map<string, IssuerSignedItem[]>()
 
@@ -171,7 +171,7 @@ export class IssuerSigned extends CborStructure<IssuerSignedEncodedStructure, Is
       })
     )
 
-    return { statusCertificate, issuanceCertificate }
+    return { trustedIssuanceCertificate, trustedStatusCertificate }
   }
 
   public static create(options: IssuerSignedOptions): IssuerSigned {

--- a/src/mdoc/models/issuer-signed.ts
+++ b/src/mdoc/models/issuer-signed.ts
@@ -3,7 +3,7 @@ import { base64url } from '@owf/identity-common'
 import { z } from 'zod'
 import type { MdocContext } from '../../context'
 import { defaultVerificationCallback, onCategoryCheck, type VerificationCallback } from '../check-callback'
-import { type GetTrustedStatusCertificates, IssuerAuth, type IssuerAuthEncodedStructure } from './issuer-auth'
+import { IssuerAuth, type IssuerAuthEncodedStructure } from './issuer-auth'
 import { IssuerNamespaces, type IssuerNamespacesEncodedStructure } from './issuer-namespaces'
 import type { IssuerSignedItem } from './issuer-signed-item'
 import type { Namespace } from './namespace'
@@ -79,14 +79,13 @@ export class IssuerSigned extends CborStructure<IssuerSignedEncodedStructure, Is
     options: {
       verificationCallback?: VerificationCallback
       now?: Date
-      trustedCertificates?: Array<Uint8Array>
-      getTrustedStatusCertificates?: GetTrustedStatusCertificates
+      trustedCertificates?: Array<{ issuance: Uint8Array[]; status?: Uint8Array[] }>
       disableCertificateChainValidation?: boolean
       disableStatusValidation?: boolean
       skewSeconds?: number
     },
     ctx: Pick<MdocContext, 'x509' | 'crypto' | 'cose' | 'fetch'>
-  ) {
+  ): Promise<{ issuanceCertificate: Uint8Array; statusCertificate?: Uint8Array }> {
     const { valueDigests, digestAlgorithm } = this.issuerAuth.mobileSecurityObject
 
     const onCheck = onCategoryCheck(options.verificationCallback ?? defaultVerificationCallback, 'DATA_INTEGRITY')
@@ -97,7 +96,7 @@ export class IssuerSigned extends CborStructure<IssuerSignedEncodedStructure, Is
     })
 
     // Verify the issuer auth
-    await this.issuerAuth.verify(options, ctx)
+    const { issuanceCertificate, statusCertificate } = await this.issuerAuth.verify(options, ctx)
 
     const namespaces = this.issuerNamespaces?.issuerNamespaces ?? new Map<string, IssuerSignedItem[]>()
 
@@ -171,6 +170,8 @@ export class IssuerSigned extends CborStructure<IssuerSignedEncodedStructure, Is
         }
       })
     )
+
+    return { statusCertificate, issuanceCertificate }
   }
 
   public static create(options: IssuerSignedOptions): IssuerSigned {

--- a/src/mdoc/models/issuer-signed.ts
+++ b/src/mdoc/models/issuer-signed.ts
@@ -3,7 +3,7 @@ import { base64url } from '@owf/identity-common'
 import { z } from 'zod'
 import type { MdocContext } from '../../context'
 import { defaultVerificationCallback, onCategoryCheck, type VerificationCallback } from '../check-callback'
-import { IssuerAuth, type IssuerAuthEncodedStructure } from './issuer-auth'
+import { type GetTrustedStatusCertificates, IssuerAuth, type IssuerAuthEncodedStructure } from './issuer-auth'
 import { IssuerNamespaces, type IssuerNamespacesEncodedStructure } from './issuer-namespaces'
 import type { IssuerSignedItem } from './issuer-signed-item'
 import type { Namespace } from './namespace'
@@ -80,7 +80,7 @@ export class IssuerSigned extends CborStructure<IssuerSignedEncodedStructure, Is
       verificationCallback?: VerificationCallback
       now?: Date
       trustedCertificates?: Array<Uint8Array>
-      trustedStatusCertificates?: Array<Uint8Array>
+      getTrustedStatusCertificates?: GetTrustedStatusCertificates
       disableCertificateChainValidation?: boolean
       disableStatusValidation?: boolean
       skewSeconds?: number

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -1,12 +1,7 @@
 import type { CoseKey } from '@owf/cose'
 import type { MdocContext } from './context.js'
 import type { VerificationCallback } from './mdoc/check-callback.js'
-import {
-  type DeviceRequest,
-  DeviceResponse,
-  type GetTrustedStatusCertificates,
-  type SessionTranscript,
-} from './mdoc/index.js'
+import { type DeviceRequest, DeviceResponse, type SessionTranscript } from './mdoc/index.js'
 
 export class Verifier {
   public static async verifyDeviceResponse(
@@ -17,8 +12,7 @@ export class Verifier {
       ephemeralReaderKey?: CoseKey
       disableCertificateChainValidation?: boolean
       disableStatusValidation?: boolean
-      trustedCertificates: Uint8Array[]
-      getTrustedStatusCertificates?: GetTrustedStatusCertificates
+      trustedCertificates: Array<{ issuance: Uint8Array[]; status?: Uint8Array[] }>
       now?: Date
       onCheck?: VerificationCallback
       skewSeconds?: number

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -1,7 +1,12 @@
 import type { CoseKey } from '@owf/cose'
 import type { MdocContext } from './context.js'
 import type { VerificationCallback } from './mdoc/check-callback.js'
-import { type DeviceRequest, DeviceResponse, type SessionTranscript } from './mdoc/index.js'
+import {
+  type DeviceRequest,
+  DeviceResponse,
+  type GetTrustedStatusCertificates,
+  type SessionTranscript,
+} from './mdoc/index.js'
 
 export class Verifier {
   public static async verifyDeviceResponse(
@@ -13,7 +18,7 @@ export class Verifier {
       disableCertificateChainValidation?: boolean
       disableStatusValidation?: boolean
       trustedCertificates: Uint8Array[]
-      trustedStatusCertificates?: Uint8Array[]
+      getTrustedStatusCertificates?: GetTrustedStatusCertificates
       now?: Date
       onCheck?: VerificationCallback
       skewSeconds?: number

--- a/tests/builders/issuer-signed-builder.test.ts
+++ b/tests/builders/issuer-signed-builder.test.ts
@@ -84,7 +84,7 @@ describe('issuer signed builder', () => {
     await expect(
       issuerSigned.issuerAuth.verify(
         {
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          trustedCertificates: [{ issuance: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)] }],
         },
         mdocContext
       )

--- a/tests/context.ts
+++ b/tests/context.ts
@@ -72,11 +72,7 @@ export const mdocContext: MdocContext = {
       return CoseKey.fromJwk((await exportJWK(key)) as unknown as Record<string, unknown>)
     },
 
-    verifyCertificateChain: async (input: {
-      trustedCertificates: Array<Uint8Array>
-      x5chain: Array<Uint8Array>
-      now?: Date
-    }) => {
+    verifyCertificateChain: async (input) => {
       const { trustedCertificates, x5chain: certificateChain } = input
       if (certificateChain.length === 0) throw new Error('Certificate chain is empty')
 
@@ -125,6 +121,8 @@ export const mdocContext: MdocContext = {
         const publicKey = previousCertificate ? previousCertificate.publicKey : undefined
         await cert?.verify({ publicKey, date: input.now ?? new Date() })
       }
+
+      return { chain: parsedChain.map((cert) => new Uint8Array(cert.rawData)) }
     },
     getCertificateData: async (input: { certificate: Uint8Array }) => {
       const certificate = new X509Certificate(input.certificate)

--- a/tests/context.ts
+++ b/tests/context.ts
@@ -77,11 +77,10 @@ export const mdocContext: MdocContext = {
       if (certificateChain.length === 0) throw new Error('Certificate chain is empty')
 
       const parsedLeafCertificate = new x509.X509Certificate(certificateChain[0])
-      const parsedMdocCertificates = certificateChain.map((c) => new x509.X509Certificate(c))
-      const parsedTrustedCertificates = trustedCertificates.map((c) => new x509.X509Certificate(c))
+      const certificatesToBuildChain = [...certificateChain, ...(trustedCertificates ?? [])].map(
+        (c) => new x509.X509Certificate(c)
+      )
 
-      // Use both trusted and mdoc certificate to build chain
-      const certificatesToBuildChain = [...parsedMdocCertificates, ...parsedTrustedCertificates]
       const certificateChainBuilder = new x509.X509ChainBuilder({
         certificates: certificatesToBuildChain,
       })
@@ -90,7 +89,7 @@ export const mdocContext: MdocContext = {
 
       // The chain is reversed here as the `x5c` header (the expected input),
       // has the leaf certificate as the first entry, while the `x509` library expects this as the last
-      let parsedChain = chain.map((c) => new x509.X509Certificate(c.rawData)).reverse()
+      let parsedChain = chain.reverse()
 
       // We allow longer parsed chain, in case the root cert was not part of the chain, but in the
       // list of trusted certificates
@@ -98,28 +97,62 @@ export const mdocContext: MdocContext = {
         throw new Error('Could not parse the full chain. Likely due to incorrect ordering')
       }
 
-      const trustedCertificateIndex = parsedChain.findIndex((cert) =>
-        parsedTrustedCertificates.some((tCert) => cert.equal(tCert))
-      )
+      let previousCertificate: X509Certificate | undefined
 
-      if (trustedCertificateIndex === -1) {
-        throw new Error('No trusted certificate was found while validating the X.509 chain')
+      if (trustedCertificates) {
+        const parsedTrustedCertificates = trustedCertificates.map(
+          (trustedCertificate) => new X509Certificate(trustedCertificate)
+        )
+
+        const trustedCertificateIndex = parsedChain.findIndex((cert) =>
+          parsedTrustedCertificates.some((tCert) => cert.equal(tCert))
+        )
+
+        if (trustedCertificateIndex === -1) {
+          throw new Error('No trusted certificate was found while validating the X.509 chain')
+        }
+
+        if (trustedCertificateIndex > 0) {
+          // When we trust a certificate other than the first certificate in the provided chain we keep a reference to the
+          // previous certificate as we need the key of this certificate to verify the first certificate in the chain as
+          // it's not self-sigend.
+          previousCertificate = parsedChain[trustedCertificateIndex - 1]
+
+          // Pop everything off before the index of the trusted certificate (those are more root) as it is not relevant for validation
+          parsedChain = parsedChain.slice(trustedCertificateIndex)
+        }
       }
-
-      // FIXME: we should remove this, and update all tests to use root cert for verification
-      // as the 'correct' way to verify is only using the root
-      // Currently if you provide a leaf certificate as trusted entities it will not verify any
-      // certificate, as we don't have the root, and can't verify the leaf without the authority key
-      // so basically it just does an equals match on whether the certificate is equal with a trusted
-      // certificate. But that also means you skip verification of the validity time of the cert
-      parsedChain = parsedChain.slice(0, trustedCertificateIndex)
 
       // Verify the certificate with the publicKey of the certificate above
       for (let i = 0; i < parsedChain.length; i++) {
         const cert = parsedChain[i]
-        const previousCertificate = parsedChain[i - 1]
         const publicKey = previousCertificate ? previousCertificate.publicKey : undefined
-        await cert?.verify({ publicKey, date: input.now ?? new Date() })
+
+        // The only scenario where this will trigger is if the trusted certificates and the x509 chain both do not contain the
+        // intermediate/root certificate needed. E.g. for ISO 18013-5 mDL the root cert MUST NOT be in the chain. If the signer
+        // certificate is then trusted, it will fail, as we can't verify the signer certifciate without having access to the signer
+        // key of the root certificate.
+        // See also https://github.com/openid/OpenID4VCI/issues/62
+        //
+        // In this case we could skip the signature verification (not other verifications), as we already trust the signer certificate,
+        // but i think the purpose of ISO 18013-5 mDL is that you trust the root certificate. If we can't verify the whole chain e.g.
+        // when we receive a credential we have the chance it will fail later on.
+        const skipSignatureVerification = i === 0 && trustedCertificates && !publicKey
+        // NOTE: at some point we might want to change this to throw an error instead of skipping the signature verification of the trusted
+        // but it would basically prevent mDOCs from unknown issuers to be verified in the wallet. Verifiers should only trust the root certificate
+        // anyway.
+        // if (i === 0 && trustedCertificates && cert.issuer !== cert.subject && !publicKey) {
+        //   throw new X509Error(
+        //     'Unable to verify the certificate chain. A non-self-signed certificate is the first certificate in the chain, and no parent certificate was found in the trusted certificates, meaning the first certificate in the chain cannot be verified. Ensure the certificate is added '
+        //   )
+        // }
+
+        if (!skipSignatureVerification) {
+          await cert.verify({
+            publicKey,
+          })
+        }
+        previousCertificate = cert
       }
 
       return { chain: parsedChain.map((cert) => new Uint8Array(cert.rawData)) }

--- a/tests/examples/animo-mdoc-05/verify.test.ts
+++ b/tests/examples/animo-mdoc-05/verify.test.ts
@@ -24,7 +24,7 @@ describe('Animo mdoc 0.5.x mdoc implementation', () => {
     await expect(
       decoded.verify(
         {
-          trustedCertificates: [new Uint8Array(rootCertificate.rawData)],
+          trustedCertificates: [{ issuance: [new Uint8Array(rootCertificate.rawData)] }],
           sessionTranscript: await SessionTranscript.forOid4Vp(
             {
               clientId,
@@ -38,6 +38,6 @@ describe('Animo mdoc 0.5.x mdoc implementation', () => {
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
   })
 })

--- a/tests/examples/bdr/verify.test.ts
+++ b/tests/examples/bdr/verify.test.ts
@@ -10,7 +10,7 @@ describe('BDR mDL implementation', () => {
 
     await issuerSigned.issuerAuth.verify(
       {
-        trustedCertificates: [new Uint8Array(issuerCertificate.rawData)],
+        trustedCertificates: [{ issuance: [new Uint8Array(issuerCertificate.rawData)] }],
         disableCertificateChainValidation: false,
         now: new Date('2026-01-01'),
       },

--- a/tests/examples/france/verify.test.ts
+++ b/tests/examples/france/verify.test.ts
@@ -14,7 +14,7 @@ describe('French playground mdoc implementation', () => {
     await expect(
       DeviceResponse.decode(deviceResponse).verify(
         {
-          trustedCertificates: [new Uint8Array(issuerCertificate.rawData)],
+          trustedCertificates: [{ issuance: [new Uint8Array(issuerCertificate.rawData)] }],
           sessionTranscript: await SessionTranscript.forOid4VpDraft18(
             {
               clientId,
@@ -28,6 +28,6 @@ describe('French playground mdoc implementation', () => {
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
   })
 })

--- a/tests/examples/google/verify.test.ts
+++ b/tests/examples/google/verify.test.ts
@@ -22,7 +22,9 @@ describe('Google CM Wallet mdoc implementation', () => {
     await expect(
       DeviceResponse.decode(deviceResponse).verify(
         {
-          trustedCertificates: [new Uint8Array(rootCertificate.rawData), new Uint8Array(signingCertificate.rawData)],
+          trustedCertificates: [
+            { issuance: [new Uint8Array(rootCertificate.rawData), new Uint8Array(signingCertificate.rawData)] },
+          ],
           sessionTranscript: await SessionTranscript.forOid4VpDcApiDraft24(
             {
               origin,
@@ -35,7 +37,7 @@ describe('Google CM Wallet mdoc implementation', () => {
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
   })
 
   test('decode and encode DeviceResponse gives same result', async () => {

--- a/tests/examples/ubique/verify.test.ts
+++ b/tests/examples/ubique/verify.test.ts
@@ -19,7 +19,7 @@ describe('Ubique mdoc implementation', () => {
     await expect(
       DeviceResponse.decode(deviceResponse).verify(
         {
-          trustedCertificates: [new Uint8Array(issuerCertificate.rawData)],
+          trustedCertificates: [{ issuance: [new Uint8Array(issuerCertificate.rawData)] }],
           sessionTranscript: await SessionTranscript.forOid4VpDraft18(
             {
               clientId,
@@ -33,6 +33,6 @@ describe('Ubique mdoc implementation', () => {
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
   })
 })

--- a/tests/verification/verify.test.ts
+++ b/tests/verification/verify.test.ts
@@ -9,7 +9,6 @@ import {
   DeviceRequest,
   DeviceResponse,
   DocRequest,
-  type GetTrustedStatusCertificates,
   Holder,
   Issuer,
   IssuerSigned,
@@ -38,23 +37,33 @@ validFrom.setMinutes(signed.getMinutes() + 5)
 const validUntil = new Date(signed)
 validUntil.setFullYear(signed.getFullYear() + 30)
 
-const validGetTrustedStatusCertificates: GetTrustedStatusCertificates = async () => {
-  return {
-    trustedStatusListCertificateChain: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-  }
-}
+const validTrustedCertificates = [
+  {
+    issuance: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+    status: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+  },
+]
 
-const invalidGetTrustedStatusCertificates: GetTrustedStatusCertificates = async () => {
-  return {
-    trustedStatusListCertificateChain: [new Uint8Array(new X509Certificate(INVALID_CERTIFICATE).rawData)],
-  }
-}
+const invalidTrustedCertificates = [
+  {
+    issuance: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+    status: [new Uint8Array(new X509Certificate(INVALID_CERTIFICATE).rawData)],
+  },
+]
 
-const emptyGetTrustedStatusCertificates: GetTrustedStatusCertificates = async () => {
-  return {
-    trustedStatusListCertificateChain: [],
-  }
-}
+const emptyTrustedCertificates = [
+  {
+    issuance: [],
+    status: [],
+  },
+]
+
+const emptyStatusTrustedCertificates = [
+  {
+    issuance: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+    status: [],
+  },
+]
 
 suite('Verification', () => {
   test('Verify simple mdoc', async () => {
@@ -84,11 +93,11 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          trustedCertificates: validTrustedCertificates,
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
 
     const deviceRequest = DeviceRequest.create({
       docRequests: [
@@ -136,7 +145,7 @@ suite('Verification', () => {
         deviceRequest,
         deviceResponse: decodedDeviceResponse,
         sessionTranscript: fakeSessionTranscript,
-        trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+        trustedCertificates: validTrustedCertificates,
       },
       mdocContext
     )
@@ -170,11 +179,11 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          trustedCertificates: validTrustedCertificates,
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
 
     const deviceRequest = DeviceRequest.create({
       docRequests: [
@@ -228,7 +237,7 @@ suite('Verification', () => {
           deviceRequest,
           deviceResponse: decodedDeviceResponse,
           sessionTranscript: fakeSessionTranscript,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          trustedCertificates: validTrustedCertificates,
         },
         mdocContext
       )
@@ -262,11 +271,11 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          trustedCertificates: validTrustedCertificates,
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
 
     const deviceRequest = DeviceRequest.create({
       docRequests: [
@@ -315,7 +324,7 @@ suite('Verification', () => {
           deviceRequest,
           deviceResponse: decodedDeviceResponse,
           sessionTranscript: fakeSessionTranscript,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          trustedCertificates: validTrustedCertificates,
         },
         mdocContext
       )
@@ -374,12 +383,11 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-          getTrustedStatusCertificates: validGetTrustedStatusCertificates,
+          trustedCertificates: validTrustedCertificates,
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
 
     const deviceRequest = DeviceRequest.create({
       docRequests: [
@@ -427,8 +435,7 @@ suite('Verification', () => {
         deviceRequest,
         deviceResponse: decodedDeviceResponse,
         sessionTranscript: fakeSessionTranscript,
-        trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-        getTrustedStatusCertificates: validGetTrustedStatusCertificates,
+        trustedCertificates: validTrustedCertificates,
       },
       mdocContext
     )
@@ -486,12 +493,11 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-          getTrustedStatusCertificates: validGetTrustedStatusCertificates,
+          trustedCertificates: validTrustedCertificates,
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
 
     const deviceRequest = DeviceRequest.create({
       docRequests: [
@@ -539,8 +545,7 @@ suite('Verification', () => {
         deviceRequest,
         deviceResponse: decodedDeviceResponse,
         sessionTranscript: fakeSessionTranscript,
-        trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-        getTrustedStatusCertificates: validGetTrustedStatusCertificates,
+        trustedCertificates: validTrustedCertificates,
       },
       mdocContext
     )
@@ -593,8 +598,7 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-          getTrustedStatusCertificates: validGetTrustedStatusCertificates,
+          trustedCertificates: validTrustedCertificates,
         },
         mdocContext
       )
@@ -603,7 +607,7 @@ suite('Verification', () => {
     )
   })
 
-  test('Verify mdoc with status status_list invalid no trusted certificates supplied', async () => {
+  test('Verify mdoc with status invalid no trusted certificates supplied', async () => {
     const idx = 3
     const uri = 'https://example.org/status-list/40'
     const statusList = new StatusList(new Array(10).fill(StatusType.Invalid), 2)
@@ -654,13 +658,70 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-          getTrustedStatusCertificates: emptyGetTrustedStatusCertificates,
+          trustedCertificates: emptyTrustedCertificates,
+        },
+        mdocContext
+      )
+    ).rejects.toThrow('No trusted certificate was found while validating the X.509 chain')
+  })
+
+  test('Verify mdoc with status status_list invalid no trusted status certificates supplied', async () => {
+    const idx = 3
+    const uri = 'https://example.org/status-list/40'
+    const statusList = new StatusList(new Array(10).fill(StatusType.Invalid), 2)
+    const statusListCwt = new StatusListCwt({
+      payload: { statusList, subject: uri },
+      protectedHeaders: ProtectedHeaders.create({
+        protectedHeaders: new Map<number, unknown>([
+          [RegisteredCwtHeaderClaimKey.X5Chain, [new X509Certificate(ISSUER_CERTIFICATE).rawData]],
+          [RegisteredCwtHeaderClaimKey.Algorithm, SignatureAlgorithm.ES256],
+        ]),
+      }),
+    })
+    statusListCwt.updateStatusList(idx, StatusType.Valid)
+    const encodedCwt = await statusListCwt.signAndEncode(
+      { signingKey: CoseKey.fromJwk(ISSUER_PRIVATE_KEY_JWK), algorithm: SignatureAlgorithm.ES256 },
+      { sign: mdocContext.cose.sign1.sign }
+    )
+    nock('https://example.org')
+      .matchHeader('Accept', /application\/statuslist\+cwt/)
+      .persist()
+      .get('/status-list/40')
+      .reply(200, Buffer.from(encodedCwt), { 'Content-Type': MediaTypes.StatusListCwt })
+
+    const issuer = new Issuer('org.iso.18013.5.1', mdocContext)
+
+    issuer.addIssuerNamespace('org.iso.18013.5.1.mDL', {
+      first_name: 'First',
+      last_name: 'Last',
+    })
+
+    const issuerSigned = await issuer.sign({
+      signingKey: CoseKey.fromJwk(ISSUER_PRIVATE_KEY_JWK),
+      certificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+      algorithm: SignatureAlgorithm.ES256,
+      digestAlgorithm: 'SHA-256',
+      deviceKeyInfo: { deviceKey: DeviceKey.fromJwk(DEVICE_JWK_PUBLIC) },
+      validityInfo: { signed, validFrom, validUntil },
+      status: { statusList: { idx: 3, uri } },
+    })
+
+    const encodedIssuerSigned = issuerSigned.encodedForOid4Vci
+
+    // openid4vci protocol
+
+    const credential = IssuerSigned.fromEncodedForOid4Vci(encodedIssuerSigned)
+
+    await expect(
+      Holder.verifyIssuerSigned(
+        {
+          issuerSigned: credential,
+          trustedCertificates: emptyStatusTrustedCertificates,
         },
         mdocContext
       )
     ).rejects.toThrow(
-      'Atleast one certificate is required to check the status of the mdoc. Make sure the `getTrustedStatusCertificates` callback is correctly imlpemented.'
+      'Atleast one certificate is required to check the status of the mdoc. Make sure to supply them in the `trustedStatusCertificates` option'
     )
   })
 
@@ -716,8 +777,7 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-          getTrustedStatusCertificates: invalidGetTrustedStatusCertificates,
+          trustedCertificates: invalidTrustedCertificates,
         },
         mdocContext
       )
@@ -776,8 +836,7 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-          getTrustedStatusCertificates: validGetTrustedStatusCertificates,
+          trustedCertificates: validTrustedCertificates,
         },
         mdocContext
       )
@@ -811,11 +870,11 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          trustedCertificates: validTrustedCertificates,
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
 
     const deviceRequest = DeviceRequest.create({
       docRequests: [
@@ -886,7 +945,7 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          trustedCertificates: validTrustedCertificates,
           now,
         },
         mdocContext
@@ -898,13 +957,13 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          trustedCertificates: validTrustedCertificates,
           now,
           skewSeconds: 600,
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
   })
 
   test('Fail to verify with not matching device request', async () => {
@@ -934,11 +993,11 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: credential,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          trustedCertificates: validTrustedCertificates,
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
 
     const deviceRequest = DeviceRequest.create({
       docRequests: [
@@ -1004,7 +1063,7 @@ suite('Verification', () => {
           deviceRequest: newDeviceRequest,
           deviceResponse: decodedDeviceResponse,
           sessionTranscript: fakeSessionTranscript,
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          trustedCertificates: validTrustedCertificates,
         },
         mdocContext
       )
@@ -1032,12 +1091,12 @@ suite('Verification', () => {
       Holder.verifyIssuerSigned(
         {
           issuerSigned: IssuerSigned.fromEncodedForOid4Vci(issuerSigned.encodedForOid4Vci),
-          trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          trustedCertificates: validTrustedCertificates,
           disableStatusValidation: true,
         },
         mdocContext
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBeDefined()
 
     // The Status payload survived signing + decode.
     const mso = issuerSigned.issuerAuth.mobileSecurityObject

--- a/tests/verification/verify.test.ts
+++ b/tests/verification/verify.test.ts
@@ -9,6 +9,7 @@ import {
   DeviceRequest,
   DeviceResponse,
   DocRequest,
+  type GetTrustedStatusCertificates,
   Holder,
   Issuer,
   IssuerSigned,
@@ -36,6 +37,24 @@ const validFrom = new Date(signed)
 validFrom.setMinutes(signed.getMinutes() + 5)
 const validUntil = new Date(signed)
 validUntil.setFullYear(signed.getFullYear() + 30)
+
+const validGetTrustedStatusCertificates: GetTrustedStatusCertificates = async () => {
+  return {
+    trustedStatusListCertificateChain: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+  }
+}
+
+const invalidGetTrustedStatusCertificates: GetTrustedStatusCertificates = async () => {
+  return {
+    trustedStatusListCertificateChain: [new Uint8Array(new X509Certificate(INVALID_CERTIFICATE).rawData)],
+  }
+}
+
+const emptyGetTrustedStatusCertificates: GetTrustedStatusCertificates = async () => {
+  return {
+    trustedStatusListCertificateChain: [],
+  }
+}
 
 suite('Verification', () => {
   test('Verify simple mdoc', async () => {
@@ -356,7 +375,7 @@ suite('Verification', () => {
         {
           issuerSigned: credential,
           trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-          trustedStatusCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          getTrustedStatusCertificates: validGetTrustedStatusCertificates,
         },
         mdocContext
       )
@@ -409,7 +428,7 @@ suite('Verification', () => {
         deviceResponse: decodedDeviceResponse,
         sessionTranscript: fakeSessionTranscript,
         trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-        trustedStatusCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+        getTrustedStatusCertificates: validGetTrustedStatusCertificates,
       },
       mdocContext
     )
@@ -468,7 +487,7 @@ suite('Verification', () => {
         {
           issuerSigned: credential,
           trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-          trustedStatusCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          getTrustedStatusCertificates: validGetTrustedStatusCertificates,
         },
         mdocContext
       )
@@ -521,7 +540,7 @@ suite('Verification', () => {
         deviceResponse: decodedDeviceResponse,
         sessionTranscript: fakeSessionTranscript,
         trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-        trustedStatusCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+        getTrustedStatusCertificates: validGetTrustedStatusCertificates,
       },
       mdocContext
     )
@@ -575,7 +594,7 @@ suite('Verification', () => {
         {
           issuerSigned: credential,
           trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-          trustedStatusCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          getTrustedStatusCertificates: validGetTrustedStatusCertificates,
         },
         mdocContext
       )
@@ -636,12 +655,12 @@ suite('Verification', () => {
         {
           issuerSigned: credential,
           trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-          trustedStatusCertificates: [],
+          getTrustedStatusCertificates: emptyGetTrustedStatusCertificates,
         },
         mdocContext
       )
     ).rejects.toThrow(
-      'Atleast one certificate is required to check the status of the mdoc. Make sure to provide it in the `trustedStatusCertificates`'
+      'Atleast one certificate is required to check the status of the mdoc. Make sure the `getTrustedStatusCertificates` callback is correctly imlpemented.'
     )
   })
 
@@ -698,7 +717,7 @@ suite('Verification', () => {
         {
           issuerSigned: credential,
           trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-          trustedStatusCertificates: [new Uint8Array(new X509Certificate(INVALID_CERTIFICATE).rawData)],
+          getTrustedStatusCertificates: invalidGetTrustedStatusCertificates,
         },
         mdocContext
       )
@@ -758,7 +777,7 @@ suite('Verification', () => {
         {
           issuerSigned: credential,
           trustedCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
-          trustedStatusCertificates: [new Uint8Array(new X509Certificate(ISSUER_CERTIFICATE).rawData)],
+          getTrustedStatusCertificates: validGetTrustedStatusCertificates,
         },
         mdocContext
       )


### PR DESCRIPTION
Callback used in credo: 
```typescript
      const getTrustedStatusCertificates: GetTrustedStatusCertificate = async (opts) => {
        let trustedStatusListCertificateChain
        if(opts.statusListCertificateChain) {
      trustedStatusListCertificateChain =
        (await x509ModuleConfig.getTrustedCertificatesForVerification?.(agentContext, {
          verification: {
            type: 'oauthTokenStatusList',
            credential: this,
          },
          certificateChain: opts.statusListCertificateChain.map((cert) => X509Certificate.fromRawCertificate(cert))
        })) ?? x509ModuleConfig.trustedCertificates
        }

        return {
          trustedStatusListCertificateChain: trustedStatusListCertificateChain?.map((cert) => X509Certificate.fromEncodedCertificate(cert).rawCertificate)
        }
      }
```
